### PR TITLE
chore: Upgrade TypeScript target to ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "target": "ES2017"
+    "target": "ES2022"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
# Why
- `tsconfig.json` set `target: "ES2017"`, missing modern language features already relied on elsewhere in the codebase's `lib` config (which includes `esnext`) — e.g. optional chaining, `Array.prototype.flatMap`.

# Fix
- Bump `compilerOptions.target` from `ES2017` to `ES2022` in tsconfig.json.

# Test
- `npm run build`: Turbopack compiled successfully, TypeScript check passed with zero errors, all 4 routes (`/`, `/_not-found`, `/chess`, `/nextjs`) prerendered as static content.
- `npm run dev`: started dev server, hit `/`, `/chess`, `/nextjs` — all returned 200 with no console/runtime errors.
- Scanned codebase for ES2022-only syntax (private fields, `static {}`, `Object.hasOwn`, `Array.at`, `Error.cause`) — none present yet, so this is a forward-compatible, non-breaking bump today.

# Issue
- Closes #11